### PR TITLE
npuw: add i4/u4 kvcache copy support without ROI tensor slicing

### DIFF
--- a/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.cpp
@@ -13,6 +13,16 @@ ov::SoPtr<ov::ITensor> ov::npuw::util::make_tensor_slice(ov::SoPtr<ov::ITensor> 
                                                          uint32_t dim,
                                                          uint32_t start_pos,
                                                          uint32_t end_pos) {
+    // Sub-byte element types (i4/u4) are not supported by make_tensor ROI path.
+    // Use copy_tensor_slice_i4() instead.
+    const auto& et = tensor->get_element_type();
+    if (et.bitwidth() < 8u) {
+        OPENVINO_ASSERT(false,
+                        "make_tensor_slice: sub-byte tensor type ",
+                        et,
+                        " is not supported by ROI tensor creation. "
+                        "Use copy_tensor_slice_i4() for i4/u4 slices.");
+    }
     ov::Shape start_shape(std::vector<size_t>(tensor->get_shape().size(), 0u));
     start_shape[dim] = start_pos;
     ov::Shape end_shape = tensor->get_shape();
@@ -171,6 +181,140 @@ std::optional<ov::Output<const ov::Node>> ov::npuw::util::find_port_by_names(
         }
     }
     return std::nullopt;
+}
+
+// ---------------------------------------------------------------------------
+// copy_tensor_slice_i4
+// ---------------------------------------------------------------------------
+// Copies [src_start, src_end) along src_dim in i4/u4 tensors without creating
+// ROI tensors. Works directly on packed bytes and handles odd (nibble-aligned)
+// offsets via boundary nibble arithmetic.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+static inline uint8_t get_i4_elem(const uint8_t* data, size_t elem_idx) {
+    const uint8_t b = data[elem_idx / 2u];
+    return (elem_idx & 1u) ? static_cast<uint8_t>((b >> 4u) & 0x0Fu) : static_cast<uint8_t>(b & 0x0Fu);
+}
+
+static inline void set_i4_elem(uint8_t* data, size_t elem_idx, uint8_t val) {
+    uint8_t& b = data[elem_idx / 2u];
+    const uint8_t nibble = static_cast<uint8_t>(val & 0x0Fu);
+    if (elem_idx & 1u) {
+        b = static_cast<uint8_t>((b & 0x0Fu) | static_cast<uint8_t>(nibble << 4u));
+    } else {
+        b = static_cast<uint8_t>((b & 0xF0u) | nibble);
+    }
+}
+
+// Copy i4/u4 scalar elements from source logical scalar index range into
+// destination scalar index range. Uses byte copy for aligned bulk and nibble
+// operations for boundary/unaligned tails.
+static void copy_i4_range(const uint8_t* src_data,
+                          size_t src_elem_begin,
+                          uint8_t* dst_data,
+                          size_t dst_elem_begin,
+                          size_t elem_count) {
+    if (elem_count == 0u)
+        return;
+
+    size_t src_idx = src_elem_begin;
+    size_t dst_idx = dst_elem_begin;
+    size_t left = elem_count;
+
+    // If parity differs, no direct byte-to-byte mapping is possible.
+    if ((src_idx & 1u) != (dst_idx & 1u)) {
+        for (size_t i = 0; i < left; ++i) {
+            set_i4_elem(dst_data, dst_idx + i, get_i4_elem(src_data, src_idx + i));
+        }
+        return;
+    }
+
+    // Same parity: peel one leading element if odd nibble-aligned, then copy
+    // full bytes, then one trailing element if needed.
+    if (src_idx & 1u) {
+        set_i4_elem(dst_data, dst_idx, get_i4_elem(src_data, src_idx));
+        ++src_idx;
+        ++dst_idx;
+        --left;
+    }
+
+    const size_t full_bytes = left / 2u;
+    std::copy_n(src_data + src_idx / 2u, full_bytes, dst_data + dst_idx / 2u);
+
+    if (left & 1u) {
+        set_i4_elem(dst_data, dst_idx + full_bytes * 2u, get_i4_elem(src_data, src_idx + full_bytes * 2u));
+    }
+}
+
+}  // anonymous namespace
+
+void ov::npuw::util::copy_tensor_slice_i4(const ov::SoPtr<ov::ITensor>& src,
+                                          uint32_t src_dim,
+                                          uint32_t src_start,
+                                          uint32_t src_end,
+                                          const ov::SoPtr<ov::ITensor>& dst,
+                                          uint32_t dst_dim,
+                                          uint32_t dst_start) {
+    OPENVINO_ASSERT(src->get_element_type().bitwidth() == 4u,
+                    "copy_tensor_slice_i4: source element type must be i4 or u4, got ",
+                    src->get_element_type());
+    OPENVINO_ASSERT(src->get_element_type() == dst->get_element_type(),
+                    "copy_tensor_slice_i4: source and destination element types must match.");
+
+    const auto& src_shape = src->get_shape();
+    const auto& dst_shape = dst->get_shape();
+    const size_t rank = src_shape.size();
+    OPENVINO_ASSERT(rank == dst_shape.size() && rank >= 1u,
+                    "copy_tensor_slice_i4: rank mismatch or empty shape.");
+    OPENVINO_ASSERT(src_dim < rank && dst_dim < rank,
+                    "copy_tensor_slice_i4: invalid slice dimension.");
+    OPENVINO_ASSERT(src_dim == dst_dim,
+                    "copy_tensor_slice_i4: src_dim != dst_dim is not supported.");
+
+    const uint32_t count = src_end - src_start;
+    OPENVINO_ASSERT(count > 0u, "copy_tensor_slice_i4: empty slice.");
+
+    const size_t slice_dim = static_cast<size_t>(src_dim);
+    const size_t src_dim_size = src_shape[slice_dim];
+    const size_t dst_dim_size = dst_shape[slice_dim];
+    OPENVINO_ASSERT(src_end <= src_dim_size,
+                    "copy_tensor_slice_i4: src_end exceeds source slice dimension size.");
+    OPENVINO_ASSERT(dst_start + count <= dst_dim_size,
+                    "copy_tensor_slice_i4: destination range exceeds destination slice dimension size.");
+
+    // Number of outer blocks = product of dimensions before sliced dim.
+    size_t num_rows = 1u;
+    for (size_t d = 0; d < slice_dim; ++d)
+        num_rows *= src_shape[d];
+
+    // Elements inside one position of sliced dim.
+    size_t inner_elems = 1u;
+    for (size_t d = slice_dim + 1u; d < rank; ++d)
+        inner_elems *= src_shape[d];
+
+    // Full tensor scalar element counts.
+    size_t src_total_elems = 1u;
+    for (const auto s : src_shape)
+        src_total_elems *= s;
+    size_t dst_total_elems = 1u;
+    for (const auto s : dst_shape)
+        dst_total_elems *= s;
+
+    const auto* src_bytes = static_cast<const uint8_t*>(src->data());
+    auto* dst_bytes = static_cast<uint8_t*>(dst->data());
+
+    for (size_t row = 0; row < num_rows; ++row) {
+        const size_t src_elem_begin = (row * src_dim_size + static_cast<size_t>(src_start)) * inner_elems;
+        const size_t dst_elem_begin = (row * dst_dim_size + static_cast<size_t>(dst_start)) * inner_elems;
+        const size_t elem_count = static_cast<size_t>(count) * inner_elems;
+        OPENVINO_ASSERT(src_elem_begin + elem_count <= src_total_elems,
+                        "copy_tensor_slice_i4: source range out of bounds.");
+        OPENVINO_ASSERT(dst_elem_begin + elem_count <= dst_total_elems,
+                        "copy_tensor_slice_i4: destination range out of bounds.");
+        copy_i4_range(src_bytes, src_elem_begin, dst_bytes, dst_elem_begin, elem_count);
+    }
 }
 
 void ov::npuw::util::pad_position_ids(const ov::SoPtr<ov::ITensor>& padded_position_ids,

--- a/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.hpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/infer_request_utils.hpp
@@ -22,6 +22,20 @@ ov::SoPtr<ov::ITensor> make_tensor_slice(ov::SoPtr<ov::ITensor> tensor,
                                          uint32_t start_pos,
                                          uint32_t end_pos);
 
+// Copy elements [src_start, src_end) along src_dim from src into dst starting
+// at dst_start along dst_dim, for i4/u4 tensors where positions may be odd
+// (sub-byte aligned). This function avoids ROI tensor creation for sub-byte
+// element types and therefore can be used where make_tensor_slice is not
+// supported.
+// Note: currently supports src_dim == dst_dim.
+void copy_tensor_slice_i4(const ov::SoPtr<ov::ITensor>& src,
+                          uint32_t src_dim,
+                          uint32_t src_start,
+                          uint32_t src_end,
+                          const ov::SoPtr<ov::ITensor>& dst,
+                          uint32_t dst_dim,
+                          uint32_t dst_start);
+
 void copy_by_planes(ov::SoPtr<ov::ITensor> src_tensor, ov::SoPtr<ov::ITensor> dst_tensor);
 
 void copy_columns_by_row_chunks(ov::SoPtr<ov::ITensor> src, ov::SoPtr<ov::ITensor>& dst);

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_base_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_base_request.cpp
@@ -28,21 +28,30 @@ void ov::npuw::LLMInferBaseRequest::update_kvcache_for(
         }
         auto dst_tensor = request->get_tensor(in_ports.at(input_name));
         const auto& kv_dim = (output_name.find("value") != std::string::npos && v_transposed) ? 3u : kvcache_desc.dim;
-        auto dst_slice = uu::make_tensor_slice(dst_tensor,
-                                               kv_dim,
-                                               kvcache_desc.num_stored_tokens - num_tokens,
-                                               kvcache_desc.num_stored_tokens);
         auto src_tensor = request->get_tensor(out_ports.at(output_name));
 
         // NOTE: Sometimes present kv layer can contain greater seq_len
         //       than was sent to be processed
-        uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
+        const uint32_t src_seq_len = static_cast<uint32_t>(src_tensor->get_shape()[kv_dim]);
         OPENVINO_ASSERT(num_tokens <= src_seq_len);
-        if (src_seq_len > num_tokens) {
-            auto src_slice = uu::make_tensor_slice(src_tensor, kv_dim, src_seq_len - num_tokens, src_seq_len);
-            uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
+        const uint32_t src_start = src_seq_len - num_tokens;
+        const uint32_t dst_start = kvcache_desc.num_stored_tokens - num_tokens;
+        const uint32_t dst_end   = kvcache_desc.num_stored_tokens;
+
+        // i4/u4 tensors cannot be sliced via ROI tensor (OV runtime does not support
+        // sub-byte strides). Use the nibble-aware direct copy for these types.
+        const bool is_i4 = (dst_tensor->get_element_type().bitwidth() == 4u);
+        if (is_i4) {
+            uu::copy_tensor_slice_i4(src_tensor, kv_dim, src_start, src_seq_len,
+                                     dst_tensor, kv_dim, dst_start);
         } else {
-            uu::copy_tensor_by_dim(src_tensor, dst_slice, kv_dim, kv_dim);
+            auto dst_slice = uu::make_tensor_slice(dst_tensor, kv_dim, dst_start, dst_end);
+            if (src_start > 0u) {
+                auto src_slice = uu::make_tensor_slice(src_tensor, kv_dim, src_start, src_seq_len);
+                uu::copy_tensor_by_dim(src_slice, dst_slice, kv_dim, kv_dim);
+            } else {
+                uu::copy_tensor_by_dim(src_tensor, dst_slice, kv_dim, kv_dim);
+            }
         }
     }
 }

--- a/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/llm_infer_request.cpp
@@ -520,6 +520,17 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
 
         const auto prefill_chunk_size = m_npuw_llm_compiled_model->m_prefill_chunk_size;
         const bool use_chunk_prefill = m_npuw_llm_compiled_model->m_use_chunk_prefill;
+        // Any ROI-based slicing for i4/u4 is unsupported by make_tensor path,
+        // so route all i4 copy ranges through the direct nibble-aware copier.
+        const bool is_i4_tensor = (prefill_out_tensor->get_element_type().bitwidth() == 4u);
+        if (is_i4_tensor) {
+            OPENVINO_ASSERT(pre_kv_dim == gen_kv_dim,
+                            "i4 KV copy currently supports src/dst on the same dim only: "
+                            "pre_kv_dim=",
+                            pre_kv_dim,
+                            ", gen_kv_dim=",
+                            gen_kv_dim);
+        }
         if (use_chunk_prefill) {
             // The chunk prefilled KV results are divided into two parts:
             // Part 1: The KV results from loops 1 to n-1 have been copied into the 'past' KV input tensor
@@ -533,57 +544,59 @@ void ov::npuw::LLMInferRequest::copy_kvcache() {
                 // Create backup of past KV tensor when buffer sharing is enabled to prevent data corruption
                 // This is necessary because subsequent copy operations would overwrite the shared buffer
                 auto prefill_past_kv = m_prefill_request->get_tensor(m_prefill_in_ports.at(input_name));
-                ov::SoPtr<ov::ITensor> tmp_dense_kv_tensor;
-                ov::SoPtr<ov::ITensor> prefill_past_kv_chunks;
+                ov::SoPtr<ov::ITensor> source_past_kv;
                 if (m_past_kv_bound) {
-                    tmp_dense_kv_tensor = ov::npuw::util::allocMem(prefill_past_kv->get_element_type(),
-                                                                   prefill_past_kv->get_shape(),
-                                                                   m_pre_alloc_device,
-                                                                   m_npuw_llm_compiled_model->get_plugin());
+                    auto tmp_dense_kv_tensor = ov::npuw::util::allocMem(prefill_past_kv->get_element_type(),
+                                                                        prefill_past_kv->get_shape(),
+                                                                        m_pre_alloc_device,
+                                                                        m_npuw_llm_compiled_model->get_plugin());
                     prefill_past_kv->copy_to(tmp_dense_kv_tensor._ptr);
-                    prefill_past_kv_chunks = make_tensor_slice(tmp_dense_kv_tensor,
-                                                               pre_kv_dim,
-                                                               0u,
-                                                               static_cast<uint32_t>(tokens_in_past_chunks));
+                    source_past_kv = tmp_dense_kv_tensor;
                 } else {
-                    prefill_past_kv_chunks = make_tensor_slice(prefill_past_kv,
-                                                               pre_kv_dim,
-                                                               0u,
-                                                               static_cast<uint32_t>(tokens_in_past_chunks));
+                    source_past_kv = prefill_past_kv;
                 }
 
-                auto kvcache_past_kv_chunks = uu::make_tensor_slice(kvcache_in_tensor,
-                                                                    gen_kv_dim,
-                                                                    0u,
-                                                                    static_cast<uint32_t>(tokens_in_past_chunks));
-
-                uu::copy_tensor_by_dim(prefill_past_kv_chunks, kvcache_past_kv_chunks, pre_kv_dim, gen_kv_dim);
+                LOG_DEBUG("Copying past KV chunks with size " << tokens_in_past_chunks << " from prefill to kv-cache tensor.");
+                if (is_i4_tensor) {
+                    uu::copy_tensor_slice_i4(source_past_kv, pre_kv_dim, 0u,
+                                             static_cast<uint32_t>(tokens_in_past_chunks),
+                                             kvcache_in_tensor, gen_kv_dim, 0u);
+                } else {
+                    auto prefill_past_kv_chunks = uu::make_tensor_slice(source_past_kv, pre_kv_dim, 0u,
+                                                                        static_cast<uint32_t>(tokens_in_past_chunks));
+                    auto kvcache_past_kv_chunks = uu::make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u,
+                                                                        static_cast<uint32_t>(tokens_in_past_chunks));
+                    uu::copy_tensor_by_dim(prefill_past_kv_chunks, kvcache_past_kv_chunks, pre_kv_dim, gen_kv_dim);
+                }
             }
-
             // Copy part 2 KV results
-            auto prefill_present_kv_chunk =
-                uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
-                                      static_cast<uint32_t>(prefill_chunk_size - m_tokens_in_present_chunk),
-                                      static_cast<uint32_t>(prefill_chunk_size));
-
-            auto kvcache_last_kv_chunk = uu::make_tensor_slice(kvcache_in_tensor,
-                                                               gen_kv_dim,
-                                                               static_cast<uint32_t>(tokens_in_past_chunks),
-                                                               kvcache_desc.num_stored_tokens);
-
-            uu::copy_tensor_by_dim(prefill_present_kv_chunk, kvcache_last_kv_chunk, pre_kv_dim, gen_kv_dim);
+            const uint32_t chunk2_src_start = static_cast<uint32_t>(prefill_chunk_size - m_tokens_in_present_chunk);
+            const uint32_t chunk2_src_end   = static_cast<uint32_t>(prefill_chunk_size);
+            const uint32_t chunk2_dst_start = static_cast<uint32_t>(tokens_in_past_chunks);
+            if (is_i4_tensor) {
+                uu::copy_tensor_slice_i4(prefill_out_tensor, pre_kv_dim, chunk2_src_start, chunk2_src_end,
+                                         kvcache_in_tensor, gen_kv_dim, chunk2_dst_start);
+            } else {
+                auto prefill_present_kv_chunk =
+                    uu::make_tensor_slice(prefill_out_tensor, pre_kv_dim, chunk2_src_start, chunk2_src_end);
+                auto kvcache_last_kv_chunk =
+                    uu::make_tensor_slice(kvcache_in_tensor, gen_kv_dim, chunk2_dst_start,
+                                         kvcache_desc.num_stored_tokens);
+                uu::copy_tensor_by_dim(prefill_present_kv_chunk, kvcache_last_kv_chunk, pre_kv_dim, gen_kv_dim);
+            }
         } else {
-            auto prefill_out_slice =
-                uu::make_tensor_slice(prefill_out_tensor,
-                                      pre_kv_dim,
-                                      kvcache_desc.max_prompt_size - kvcache_desc.num_stored_tokens,
-                                      kvcache_desc.max_prompt_size);
-
-            auto kvcache_in_slice =
-                uu::make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u, kvcache_desc.num_stored_tokens);
-
-            uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, pre_kv_dim, gen_kv_dim);
+            const uint32_t src_start = kvcache_desc.max_prompt_size - kvcache_desc.num_stored_tokens;
+            const uint32_t src_end   = kvcache_desc.max_prompt_size;
+            if (is_i4_tensor) {
+                uu::copy_tensor_slice_i4(prefill_out_tensor, pre_kv_dim, src_start, src_end,
+                                         kvcache_in_tensor, gen_kv_dim, 0u);
+            } else {
+                auto prefill_out_slice =
+                    uu::make_tensor_slice(prefill_out_tensor, pre_kv_dim, src_start, src_end);
+                auto kvcache_in_slice =
+                    uu::make_tensor_slice(kvcache_in_tensor, gen_kv_dim, 0u, kvcache_desc.num_stored_tokens);
+                uu::copy_tensor_by_dim(prefill_out_slice, kvcache_in_slice, pre_kv_dim, gen_kv_dim);
+            }
         }
     });
     LOG_DEBUG("Done.");

--- a/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/convert_kvcache_to_precision.cpp
+++ b/src/plugins/intel_npu/src/plugin/npuw/npuw_transformations/convert_kvcache_to_precision.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<ov::Model> cvt_kvcache_to_low_precision(const std::shared_ptr<ov
     if (use_integer_kv_storage) {
         key_storage_type = lptype;
         //TODO: int4 precision for value-cachelead to compilation failure for now
-        value_storage_type = ov::element::i8;
+        value_storage_type = ov::element::i4;
     }
 
     ov::preprocess::PrePostProcessor ppp(model);


### PR DESCRIPTION
Stacked PR on top of i8 feature branch to keep diff limited to i4/u4 copy support only.

This changeset adds nibble-aware i4/u4 KV-cache copy logic and avoids ROI tensor slicing for sub-byte types.